### PR TITLE
add expiration date to potlucks in database

### DIFF
--- a/potlucky-server/src/main.py
+++ b/potlucky-server/src/main.py
@@ -1,10 +1,13 @@
 import uuid
+from datetime import datetime
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from botocore.exceptions import ClientError
 
 from src.models.potluck import PotluckPayload, PotluckItem, DishPayload, Dish
 from src.dynamodb.client import dynamodb_client
+
+THIRTY_DAYS_IN_SECONDS = 2592000
 
 app = FastAPI()
 
@@ -19,10 +22,14 @@ app.add_middleware(
 @app.post("/potluck")
 def create_potluck(payload: PotluckPayload):
     potluckId = str(uuid.uuid4())
+    potluck_datetime = datetime.fromisoformat(payload.datetime.replace('Z', '+00:00'))
+    expire_at = int(potluck_datetime.timestamp()) + THIRTY_DAYS_IN_SECONDS
+    
     try:
         dynamodb_client.create_potluck(PotluckItem(
             potluckId=potluckId,
-            **payload.model_dump()
+            **payload.model_dump(),
+            expire_at=expire_at
         ))
     except ClientError as e:
         raise HTTPException(status_code=500, detail="Something went wrong")

--- a/potlucky-server/src/models/potluck.py
+++ b/potlucky-server/src/models/potluck.py
@@ -20,4 +20,4 @@ class PotluckPayload(BaseModel):
 class PotluckItem(PotluckPayload):
     potluckId: str
     dishes: dict[str, DishPayload] = {}
-
+    expire_at: int


### PR DESCRIPTION
closes #5 

A new field called `expire_at` will exist on all potluck items created. TTL has been enabled and configured to use that field for item cleanup.